### PR TITLE
Fix/zlib-tor-build-osx

### DIFF
--- a/mkpm_modules/pkg/http-parser/spec.sh
+++ b/mkpm_modules/pkg/http-parser/spec.sh
@@ -3,6 +3,9 @@ pkg_repo=https://github.com/nodejs/http-parser
 
 pkg_make() {
     cd $mkpm_root/src/$pkg_name
+    if [ -z "$CC" ]; then
+        CC=cc
+    fi
     $CC $CPPFLAGS $CFLAGS -I. -c -o http_parser.o http_parser.c
     ar cr libhttp_parser.a http_parser.o
 }

--- a/script/mkpm-install-plumbing
+++ b/script/mkpm-install-plumbing
@@ -109,10 +109,6 @@ echo "* $1"
 export CPPFLAGS="$CPPFLAGS -I$mkpm_root/dist/include"
 export LDFLAGS="$LDFLAGS -L$mkpm_root/dist/lib"
 
-# Provide default CC and CXX
-if [ -z "$CC" ]; then export CC="cc"; fi
-if [ -z "$CXX" ]; then export CXX="c++"; fi
-
 echo "- spec($1)"
 mkpm_get_resource pkg/$1/spec.sh
 . $mkpm_root/pkg/$1/spec.sh


### PR DESCRIPTION
This fixes building tor on my osx. <strike>Apparently, because zlib compiles a dynamic library with the wrong extension. **Before merging** I'd like to understand why the same code works on travis :-).</strike>

It turns out that pre-setting `CC` in `mkpm-install-plumbing` when it was not set confused zlib's `./configure` script that hence generated libraries with invalid suffix for osx.
